### PR TITLE
feat(plugin): :sparkles: add schema validation APIs and documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,8 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Build project
+        run: bun run build
+
       - name: Run unit tests
         run: bun run test

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ export default defineConfig([
     language: 'css/css',
     extends: ['css/recommended'],
   },
-  eslintPluginPrettierRecommended,
+  { ...eslintPluginPrettierRecommended, ignores: ['**/*.md'] },
   {
     rules: {
       // @eslint/markdown doesn't support GitHub Flavored Markdown (GFM) Alerts yet eslint/markdown#294

--- a/packages/plugin/src/__test__/fake-programs/index.ts
+++ b/packages/plugin/src/__test__/fake-programs/index.ts
@@ -1,8 +1,16 @@
 // @ts-expect-error - it should exist
-import { validateUser } from './test.valype'
+import { validateUser, isUser, assertUser } from './test.valype'
 
 const result = validateUser({
   name: 'John Doe',
 })
+console.log(`result ==>`, result)
 
-console.log(result)
+const is = isUser({ name: '1', age: 2, email: '3' })
+console.log(`is ==>`, is)
+
+try {
+  assertUser({ message: 'What can I say? Man!' })
+} catch (error) {
+  console.log(`error ==>`, error)
+}

--- a/packages/plugin/src/__test__/index.test.ts
+++ b/packages/plugin/src/__test__/index.test.ts
@@ -89,11 +89,25 @@ describe('unplugin-valype', () => {
             const result = UserSchema.safeParse(data);
             return result.error?.issues;
           }
+          function isUser(data) {
+            return validateUser(data) === void 0;
+          }
+          function assertUser(data) {
+            const issues = validateUser(data);
+            if (issues) throw issues;
+          }
 
           const result = validateUser({
             name: "John Doe"
           });
-          console.log(result);
+          console.log(\`result ==>\`, result);
+          const is = isUser({ name: "1", age: 2, email: "3" });
+          console.log(\`is ==>\`, is);
+          try {
+            assertUser({ message: "What can I say? Man!" });
+          } catch (error) {
+            console.log(\`error ==>\`, error);
+          }
           ",
                 "names": "index",
               },
@@ -126,7 +140,28 @@ describe('unplugin-valype', () => {
         )
 
         expect(stdout).toMatchInlineSnapshot(`
-          "[
+          "result ==> [
+            {
+              expected: 'number',
+              code: 'invalid_type',
+              path: [ 'age' ],
+              message: 'Invalid input: expected number, received undefined'
+            },
+            {
+              expected: 'string',
+              code: 'invalid_type',
+              path: [ 'email' ],
+              message: 'Invalid input: expected string, received undefined'
+            }
+          ]
+          is ==> true
+          error ==> [
+            {
+              expected: 'string',
+              code: 'invalid_type',
+              path: [ 'name' ],
+              message: 'Invalid input: expected string, received undefined'
+            },
             {
               expected: 'number',
               code: 'invalid_type',

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -84,7 +84,16 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = () => {
               `export function validate${e.interface}(data: unknown): $ZodIssue[] | undefined {
   const result = ${e.schema}.safeParse(data)
   return result.error?.issues
-            }`,
+}
+
+export function is${e.interface}(data: unknown): data is ${e.interface} {
+  return validate${e.interface}(data) === undefined
+}
+
+export function assert${e.interface}(data: unknown): asserts data is ${e.interface} {
+  const issues = validate${e.interface}(data)
+  if (issues) throw issues
+}`,
           )
           .join('\n'),
       )

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
         items: [
           { text: 'What is Valype?', link: '/what-is-valype' },
           { text: 'Getting Started', link: '/getting-started' },
+          { text: 'API Reference', link: '/api-reference' },
         ],
       },
     ],

--- a/website/src/api-reference.md
+++ b/website/src/api-reference.md
@@ -1,0 +1,58 @@
+# API Reference
+
+## Schema Validation APIs
+
+### `validate${schemaName}`
+
+```typescript
+function validate${schemaName}(data: unknown): ZodIssue[] | undefined
+```
+
+Validates data against the schema. Returns:
+
+- `undefined` if validation passes
+- Array of `ZodIssue` objects if validation fails
+
+Example:
+
+```typescript
+const issues = validateUser(data)
+if (issues) {
+  // handle validation errors
+}
+```
+
+### `is${schemaName}`
+
+```typescript
+function is${schemaName}(data: unknown): data is ${schemaName}
+```
+
+Type predicate that checks if data matches the schema. Returns `true` if valid.
+
+Example:
+
+```typescript
+if (isUser(data)) {
+  // data is now typed as User
+}
+```
+
+### `assert${schemaName}`
+
+```typescript
+function assert${schemaName}(data: unknown): asserts data is ${schemaName}
+```
+
+Validates data and throws validation issues if invalid. If it returns, data is guaranteed to match the schema type.
+
+Example:
+
+```typescript
+try {
+  assertUser(data)
+  // data is now typed as User
+} catch (issues) {
+  // handle validation errors
+}
+```


### PR DESCRIPTION
* Add `is${schemaName}` type predicate
* Add `assert${schemaName}` type assertion function
* Update API reference documentation
* Add API docs to VitePress navaigation
* Rename `validate${schemaName}ThrowError` as a result of discuss before to more concise `assert${schemaName}`

## Type Hinting Notice

The current implementation of `is${schemaName}` and `assert${schemaName}` APIs cannot provide full type hinting functionality as the TypeScript plugin is still under development.

Progress can be tracked in these issues:
* #5 
* #6 

These features will be implemented in future releases. The current version still performs runtime validation, but lacks static type hints.

Closes #27 